### PR TITLE
Force HTTPS connection with Apache redirect

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: vendor/bin/heroku-php-apache2 phpmyadmin/
+web: vendor/bin/heroku-php-apache2 -C rewrite.conf phpmyadmin/

--- a/rewrite.conf
+++ b/rewrite.conf
@@ -1,0 +1,13 @@
+RewriteEngine On
+
+# If we receive a forwarded http request from a proxy...
+RewriteCond %{HTTP:X-Forwarded-Proto} =http [OR]
+
+# ...or just a plain old http request directly from the client
+RewriteCond %{HTTP:X-Forwarded-Proto} =""
+RewriteCond %{HTTPS} !=on
+
+# Redirect to https version
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+DirectoryIndex index.php index.html index.htm


### PR DESCRIPTION
The ForceSSL configuration element has been deprecated on phpMyAdmin https://docs.phpmyadmin.net/en/latest/config.html#cfg_ForceSSL, so the default deployment of this app allows plaintext connections to the Heroku app.

This Apache configuration adds an HTTP to HTTPS redirect.  There's probably no reason to access phpMyAdmin over HTTP at Heroku, so this seems like a more secure default.  If someone wants to remove the redirect, they can remove the custom configuration from the `Procfile`